### PR TITLE
Only set cache_picker cached_prompt if it's non empty (/not a space)

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1544,9 +1544,14 @@ function pickers.on_close_prompt(prompt_bufnr)
           picker.manager = EntryManager:new(picker.max_results, picker.entry_adder, picker.stats)
         end
       end
-      picker.default_text = picker:_get_prompt()
+      local curr_prompt = picker:_get_prompt()
+      picker.default_text = curr_prompt
       picker.cache_picker.selection_row = picker._selection_row
-      picker.cache_picker.cached_prompt = picker:_get_prompt()
+      -- Check if curr_prompt is not empty and then only set picket.cache_picker.cached_prompt
+      if (curr_prompt ~= "") or (curr_prompt ~= " ") then
+        print("curr_prompt", curr_prompt)
+        picker.cache_picker.cached_prompt = curr_prompt
+      end
       picker.cache_picker.is_cached = true
       table.insert(cached_pickers, 1, picker)
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1548,8 +1548,8 @@ function pickers.on_close_prompt(prompt_bufnr)
       picker.default_text = curr_prompt
       picker.cache_picker.selection_row = picker._selection_row
       -- Check if curr_prompt is not empty and then only set picket.cache_picker.cached_prompt
+      print("curr_prompt", curr_prompt)
       if (curr_prompt ~= "") or (curr_prompt ~= " ") then
-        print("curr_prompt", curr_prompt)
         picker.cache_picker.cached_prompt = curr_prompt
       end
       picker.cache_picker.is_cached = true


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
